### PR TITLE
Removed useCreateIndex from Database Provider

### DIFF
--- a/src/providers/Database.ts
+++ b/src/providers/Database.ts
@@ -19,8 +19,6 @@ export class Database {
 
 		(<any>mongoose).Promise = bluebird;
 
-		mongoose.set('useCreateIndex', true);
-
 		mongoose.connect(dsn, options, (error: MongoError) => {
 			// handle the error case
 			if (error) {


### PR DESCRIPTION
I've removed the use of "**useCreateIndex**" from database provider named [Database.ts](https://github.com/GeekyAnts/express-typescript/blob/master/src/providers/Database.ts).

For you reference, please check https://github.com/Automattic/mongoose/issues/10732.